### PR TITLE
Change name of docker image when needs to run in pwnenv Linux function

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ function pwnenv() {
     if [ $(checkContainerRunning "pwnenv") ]; then
         docker exec -it pwnenv zsh
     else
-        docker run --net=host --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -it --rm --name "pwnenv" -v "$(pwd)":/root/data "pwnenv"
+        docker run --net=host --cap-add=SYS_PTRACE --security-opt seccomp=unconfined -it --rm --name "pwnenv" -v "$(pwd)":/root/data "christoss/pwnenv"
     fi
 }
 ```


### PR DESCRIPTION
When docker pulling the image, it names it "christoss/pwnenv", so a minor tweak was needed for the function to run the image. 